### PR TITLE
refactor: simply the expression by removing redundant boolean literals

### DIFF
--- a/OOIT/IT 02-2017 Neskovic Bojana/src/gui/Drawing.java
+++ b/OOIT/IT 02-2017 Neskovic Bojana/src/gui/Drawing.java
@@ -389,7 +389,7 @@ public class Drawing extends JFrame {
 							null
 							);
 					if (rezultat == JOptionPane.OK_OPTION) {
-						if(chckbxPopuniUnutrasnjost.isSelected()== true){
+						if(chckbxPopuniUnutrasnjost.isSelected()){
 							pnlCentar.addShape(new Rectangle(new Point(x, y), (int)unesiSirinu.getValue(),(int)unesiVisinu.getValue(), colorEdges, colorInside));
 							
 						}

--- a/OOIT/src/gui/Drawing.java
+++ b/OOIT/src/gui/Drawing.java
@@ -389,7 +389,7 @@ public class Drawing extends JFrame {
 							null
 							);
 					if (rezultat == JOptionPane.OK_OPTION) {
-						if(chckbxPopuniUnutrasnjost.isSelected()== true){
+						if(chckbxPopuniUnutrasnjost.isSelected()){
 							pnlCentar.addShape(new Rectangle(new Point(x, y), (int)unesiSirinu.getValue(),(int)unesiVisinu.getValue(), colorEdges, colorInside));
 							
 						}


### PR DESCRIPTION
Boolean literals should not be used redundantly within expressions.